### PR TITLE
I just bought charles proxy for 30% off and saw that it's missing here

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This is a list of all Black Friday Deals for macOS software and Swift tutorials 
 ### [iStat Menus 6 | 50% off 💸](https://bjango.com/mac/istatmenus/)
 ### [CleanMyMac X, Gemini 2, Hider 2 |30% off 💰](https://macpaw.com/store)
 ### [Sip | 50% off 💸](https://sipapp.io)
+### [Charles Proxy | 30% off 💸](https://twitter.com/charlesproxy/status/1065698785194459136)
 
 ## 🖥 Virtualization Software
 ### [Parallels Desktop | 20% off 💰](https://www.parallels.com/)


### PR DESCRIPTION
Linking to the twitter post that contains the code: CHARLESBLACK18