### PR TITLE
Add The Pragmatic Bookshelf deals

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ This is a list of all Black Friday Deals for macOS / iOS Software & Books in 201
 ### [Objective-C for Swift Developers | 50% off 💸](https://gumroad.com/l/objcswift/blackfriday19)
 ### [Server-side Swift: Kitura Edition | 50% off 💸](https://gumroad.com/l/server-side-swift/blackfriday19)
 ### [Beyond Code | 50% off 💸](https://gumroad.com/l/beyondcode/blackfriday19)
+### [iOS Unit Testing by Example | 40% off 💸](https://pragprog.com/book/jrlegios/ios-unit-testing-by-example) with discount code *turkeysale2019*
+### [Xcode Treasures | 40% off 💸](https://pragprog.com/book/caxcode/xcode-treasures) with discount code *turkeysale2019*
+### [Swift Style | 40% off 💸](https://pragprog.com/book/esswift2/swift-style-second-edition) with discount code *turkeysale2019*
 
 ## ☁️ Servers	
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ This is a list of all Black Friday Deals for macOS / iOS Software & Books in 201
 ### [Objective-C for Swift Developers | 50% off 💸](https://gumroad.com/l/objcswift/blackfriday19)
 ### [Server-side Swift: Kitura Edition | 50% off 💸](https://gumroad.com/l/server-side-swift/blackfriday19)
 ### [Beyond Code | 50% off 💸](https://gumroad.com/l/beyondcode/blackfriday19)
-### [iOS Unit Testing by Example | 40% off 💸](https://pragprog.com/book/jrlegios/ios-unit-testing-by-example) with discount code *turkeysale2019*
-### [Xcode Treasures | 40% off 💸](https://pragprog.com/book/caxcode/xcode-treasures) with discount code *turkeysale2019*
-### [Swift Style | 40% off 💸](https://pragprog.com/book/esswift2/swift-style-second-edition) with discount code *turkeysale2019*
+### [iOS Unit Testing by Example | 40% off 💰](https://pragprog.com/book/jrlegios/ios-unit-testing-by-example) with discount code *turkeysale2019*
+### [Xcode Treasures | 40% off 💰](https://pragprog.com/book/caxcode/xcode-treasures) with discount code *turkeysale2019*
+### [Swift Style | 40% off 💰](https://pragprog.com/book/esswift2/swift-style-second-edition) with discount code *turkeysale2019*
 
 ## ☁️ Servers	
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This is a list of all Black Friday Deals for macOS / iOS Software & Books in 201
 ### [iOS Unit Testing by Example | 40% off 💰](https://pragprog.com/book/jrlegios/ios-unit-testing-by-example) with discount code *turkeysale2019*
 ### [Xcode Treasures | 40% off 💰](https://pragprog.com/book/caxcode/xcode-treasures) with discount code *turkeysale2019*
 ### [Swift Style | 40% off 💰](https://pragprog.com/book/esswift2/swift-style-second-edition) with discount code *turkeysale2019*
+### [A Swift Kickstart | 40% off 💰](https://pragprog.com/book/d-dsswift/a-swift-kickstart-second-edition) with discount code *turkeysale2019*
 
 ## ☁️ Servers	
 


### PR DESCRIPTION
Hi,

I found a couple of interesting iOS/Swift deals at [The Pragmatic Bookshelf](https://pragprog.com). Most of their catalogue seems to be off by 40% until December 4th.

There are a couple of interesting publications regarding Swift & iOS development, including Chris Adamson's [Xcode Treasures](https://pragprog.com/book/caxcode/xcode-treasures), second edition of Erica Sadun's book [Swift Style](https://pragprog.com/book/esswift2/swift-style-second-edition) and newest publication from Jon Reid, [iOS Unit Testing by Example](https://pragprog.com/book/jrlegios/ios-unit-testing-by-example).

All of these books can be purchased with discount code [**turkeysale2019**](https://pragprog.com/promotions).

Hope you'll enjoy!