### PR TITLE
Update Paw (100% off)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is a list of all Black Friday Deals for macOS / iOS Software & Books in 201
 ### [Git Kraken | 20% off 💰](https://www.gitkraken.com) - Git desktop client for Mac and Windows
 ### [Proxyman | 50% off 💸](https://proxyman.io) - Native, Modern and Delightful Web Debugging Proxy for macOS, iOS, Android.
 ### [SQLPro Studio | 50% off 💸](https://www.sqlprostudio.com/blackfriday.html) - A fully native database client for macOS and iOS.
-### [Paw | 50% off 💸](https://www.macheist.com/sales/paw-the-most-advanced-api-tool-for-mac) - REST Client
+### [Paw | 100% off 💸](https://twitter.com/luckymarmot/status/1200440962163650561) - REST Client
 ### [StudIO Code | 50% off 💸](https://studiocode.app) - The first hackable code editor for iOS
 ### [Charles | 30% off💰](http://charlesproxy.com) - with code CHARLESBLACK19
 ### [RapidWeaver 8 | 30% off 💸](https://www.realmacsoftware.com/black/) - web design software for Mac


### PR DESCRIPTION
Paw have a better offer on their Twitter page, which gives a license for free if you retweet them, and send them a Direct Message about it. 50% offer still available on their website, with profits going to climate change.