### PR TITLE
Add ShutterCheck Deal

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This is a list of all Black Friday Deals for macOS / iOS Software & Books in 201
 ### [AirBuddy | 20% off 💰](https://gumroad.com/l/airbuddy/BF2019) - The same AirPods experience you have on iOS to the Mac.
 ### [SmartNFC | 50% off 💸](https://apps.apple.com/us/app/smart-nfc/id1470146079) - Read, write and interact with NFC tags.
 ### [Bitdefender | 50% off💸](https://www.bitdefender.com/solutions/) Antivirus for Mac / Windows / iOS / Android.
+### [ShutterCheck | 20% off 💰](https://shuttercheck.app) — Get shutter actuations count of your Canon EOS camera
 
 ## 📌 Productivity Software
 ### [FocusList | 60% off 💸](http://focuslist.co) - Daily planner based on Pomodoro technique


### PR DESCRIPTION
My macOS app [ShutterCheck](https://shuttercheck.app) is 20% off on the Mac App Store for Black Friday through Cyber Monday.