### PR TITLE
Improve readability, add Pragmatic Bookshelf offer

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ This is a list of all Black Friday Deals for macOS / iOS Software & Books in 202
 ### 💸 [Beyond Code](https://gumroad.com/l/beyondcode/blackfriday20) · 50% off
 ### 💸 [Making Sense of Auto Layout](https://autolayout.fluffy.es) · 50% off
 ### 💸 [Practical Sign in with Apple](https://siwa.fluffy.es) · 50% off
+### 💰 [Pragmatic Bookshelf (all ebooks and audiobooks)](https://pragprog.com) · 40% off · Code: turkeysale2020
+For example:
+
+* Daniel Steinberg: [_A Swift Kickstart_](https://pragprog.com/titles/d-dsswift2/a-swift-kickstart-second-edition/) and [_A SwiftUI Kickstart_](https://pragprog.com/titles/d-dsswiftui/a-swiftui-kickstart/)
+* Erica Sadun: [_Swift Style_](https://pragprog.com/titles/esswift2/swift-style-second-edition/)
+* Dominik Hauser: [_Build Location-Based Projects for iOS_](https://pragprog.com/titles/dhios/build-location-based-projects-for-ios/)
+* Tammy Coron: [_Apple Game Frameworks and Technologies_](https://pragprog.com/titles/tcswift/apple-game-frameworks-and-technologies/)
+* Chris Adamson: [_Xcode Treasures_](https://pragprog.com/titles/caxcode/xcode-treasures/)
+* Marcus Zarra: [_Core Data in Swift_](https://pragprog.com/titles/mzswift/core-data-in-swift/)
 
 ## 👩‍🎓 Courses and Videos
 

--- a/README.md
+++ b/README.md
@@ -4,69 +4,69 @@ This is a list of all Black Friday Deals for macOS / iOS Software & Books in 202
 **Legend**
 
 | Emoji | Savings |
-|-----|---|
-| 💰 | < 50% |
-| 💸 | >= 50% |
+|:-----:|--------:|
+| 💰    | < 50%   |
+| 💸    | >= 50%  |
 
 
 ## 🛠 Development Software
 
-### [Proxyman | 30% off 💰](https://proxyman.io) - Native and Modern Web Debugging Proxy for macOS, iOS and Android. Use code **PROXYMAN_BLACK_FRIDAY_2020**
+### 💰 [Proxyman](https://proxyman.io) - Native and Modern Web Debugging Proxy for macOS, iOS and Android. · 30% off · Code: **PROXYMAN_BLACK_FRIDAY_2020**
 
 ## 🎛 Utility Software
 
-### [Hummingbird | 33% off 💰](https://hbird.app) - Make macOS window management a breeze
-### [Fontastic | 100% off 💸](https://apps.apple.com/app/id1537294729) - Browse & install 1000+ fonts for iPad and iPhone (iOS)
+### 💰 [Hummingbird](https://hbird.app) – Make macOS window management a breeze · 33% off
+### 💸 [Fontastic](https://apps.apple.com/app/id1537294729) – Browse & install 1000+ fonts for iPad and iPhone (iOS) · 100% off
 
 
-### [All Windows Appear | 50% off 💰](https://apps.apple.com/app/id1494564769) – Classic Window Behavior (macOS)
+### 💰 [All Windows Appear](https://apps.apple.com/app/id1494564769) – Classic Window Behavior (macOS) · 50% off
 
 ## 📌 Productivity Software
 
-### [Theine | 50% off 💰](https://apps.apple.com/app/id955848755) – Keeps Your Mac Awake (macOS)
+### 💰 [Theine](https://apps.apple.com/app/id955848755) – Keeps Your Mac Awake (macOS) · 50% off
 
 ## 🎨 Graphic Software
 
-### [Entity Pro | 50% off 💰](https://apps.apple.com/app/id1503988785) – Glyph & Emoji Finder (macOS)
+### 💰 [Entity Pro](https://apps.apple.com/app/id1503988785) – Glyph & Emoji Finder (macOS) · 50% off
 
-### [Color UI | 50% off IAP 💰](https://apps.apple.com/app/id1092899208) – Colorful. Powerful. Wonderful! Color palettes made effortless. (macOS)
+### 💰 [Color UI](https://apps.apple.com/app/id1092899208) – Colorful. Powerful. Wonderful! Color palettes made effortless. (macOS) · 50% off IAP
 
-### [Adobe Creative Cloud | 20% off (EU) / 25% off (US) 💰](https://www.adobe.com/creativecloud.html)
+### 💰 [Adobe Creative Cloud](https://www.adobe.com/creativecloud.html) · 20% off (EU) / 25% off (US)
 
 ## 🎓 Reference & Education
 
-### [V for Wikipedia | 50% off 💰](https://apps.apple.com/app/id993435362) — Read Wikipedia, better than ever (iOS)
+### 💰 [V for Wikipedia](https://apps.apple.com/app/id993435362) – Read Wikipedia, better than ever (iOS) · 50% off
 
 ## 📖 Books
 
-### [The Swift Power Pack (includes six books) | 50% off 💸](https://gumroad.com/l/swift-power-pack/blackfriday20)
-### [The Swift Platform Pack (includes six books) | 50% off 💸](https://gumroad.com/l/swift-platform-pack/blackfriday20)
-### [The Swift Plus Pack (includes six books) | 50% off 💸](https://gumroad.com/l/swift-plus-pack/blackfriday20)
-### [SwiftUI By Example | 50% off 💸](https://gumroad.com/l/swiftui/blackfriday20)
-### [Pro Swift | 50% off 💸](https://gumroad.com/l/proswift/blackfriday20)
-### [Swift Design Patterns | 50% off 💸](https://gumroad.com/l/swift-design-patterns/blackfriday20)
-### [Testing Swift | 50% off 💸](https://gumroad.com/l/testing-swift/blackfriday20)
-### [Hacking with iOS (includes UIKit and SwiftUI) | 50% off 💸](https://gumroad.com/l/hws-book-pack/blackfriday20)
-### [Advanced iOS: Volume One | 50% off 💸](https://gumroad.com/l/advanced-ios-1/blackfriday20)
-### [Advanced iOS: Volume Two | 50% off 💸](https://gumroad.com/l/advanced-ios-2/blackfriday20)
-### [Advanced iOS: Volume Three | 50% off 💸](https://gumroad.com/l/advanced-ios-3/blackfriday20)
-### [Hacking with macOS | 50% off 💸](https://gumroad.com/l/hwmacos/blackfriday20)
-### [Hacking with watchOS | 50% off 💸](https://gumroad.com/l/hwwatchos/blackfriday20)
-### [Hacking with tvOS | 50% off 💸](https://gumroad.com/l/hwtvos/blackfriday20)
-### [Swift on Sundays: Volume One | 50% off 💸](https://gumroad.com/l/swift-on-sundays-1/blackfriday20)
-### [Dive Into SpriteKit | 50% off 💸](https://gumroad.com/l/dive-into-spritekit/blackfriday20)
-### [Understanding Swift | 50% off 💸](https://gumroad.com/l/understanding-swift/blackfriday20)
-### [Swift in Sixty Seconds | 50% off 💸](https://gumroad.com/l/sixty/blackfriday20)
-### [Objective-C for Swift Developers | 50% off 💸](https://gumroad.com/l/objcswift/blackfriday20)
-### [Beyond Code | 50% off 💸](https://gumroad.com/l/beyondcode/blackfriday20)
-### [Making Sense of Auto Layout | 50% off 💸](https://autolayout.fluffy.es)
-### [Practical Sign in with Apple | 50% off 💸](https://siwa.fluffy.es)
+### 💸 [The Swift Power Pack (includes six books)](https://gumroad.com/l/swift-power-pack/blackfriday20) · 50% off
+### 💸 [The Swift Platform Pack (includes six books)](https://gumroad.com/l/swift-platform-pack/blackfriday20) · 50% off
+### 💸 [The Swift Plus Pack (includes six books)](https://gumroad.com/l/swift-plus-pack/blackfriday20) · 50% off
+### 💸 [SwiftUI By Example](https://gumroad.com/l/swiftui/blackfriday20) · 50% off
+### 💸 [Pro Swift](https://gumroad.com/l/proswift/blackfriday20) · 50% off
+### 💸 [Swift Design Patterns](https://gumroad.com/l/swift-design-patterns/blackfriday20) · 50% off
+### 💸 [Testing Swift](https://gumroad.com/l/testing-swift/blackfriday20) · 50% off
+### 💸 [Hacking with iOS (includes UIKit and SwiftUI)](https://gumroad.com/l/hws-book-pack/blackfriday20) · 50% off
+### 💸 [Advanced iOS: Volume One](https://gumroad.com/l/advanced-ios-1/blackfriday20) · 50% off
+### 💸 [Advanced iOS: Volume Two](https://gumroad.com/l/advanced-ios-2/blackfriday20) · 50% off
+### 💸 [Advanced iOS: Volume Three](https://gumroad.com/l/advanced-ios-3/blackfriday20) · 50% off
+### 💸 [Hacking with macOS](https://gumroad.com/l/hwmacos/blackfriday20) · 50% off
+### 💸 [Hacking with watchOS](https://gumroad.com/l/hwwatchos/blackfriday20) · 50% off
+### 💸 [Hacking with tvOS](https://gumroad.com/l/hwtvos/blackfriday20) · 50% off
+### 💸 [Swift on Sundays: Volume One](https://gumroad.com/l/swift-on-sundays-1/blackfriday20) · 50% off
+### 💸 [Dive Into SpriteKit](https://gumroad.com/l/dive-into-spritekit/blackfriday20) · 50% off
+### 💸 [Understanding Swift](https://gumroad.com/l/understanding-swift/blackfriday20) · 50% off
+### 💸 [Swift in Sixty Seconds](https://gumroad.com/l/sixty/blackfriday20) · 50% off
+### 💸 [Objective-C for Swift Developers](https://gumroad.com/l/objcswift/blackfriday20) · 50% off
+### 💸 [Beyond Code](https://gumroad.com/l/beyondcode/blackfriday20) · 50% off
+### 💸 [Making Sense of Auto Layout](https://autolayout.fluffy.es) · 50% off
+### 💸 [Practical Sign in with Apple](https://siwa.fluffy.es) · 50% off
 
 ## 👩‍🎓 Courses and Videos
 
-### [Hacking with Swift+ Annual Subscription | $40 off 💰](https://gumroad.com/l/hws-subscription?yearly=true)
-### [SwiftUI Masterclass Course | 60% off 💸](https://swiftuimasterclass.com)
-### [Combine Swift • Complete Course | $40 off 💰](https://combineswift.com)
+### 💰 [Hacking with Swift+ Annual Subscription](https://gumroad.com/l/hws-subscription?yearly=true) · $40 off
+### 💸 [SwiftUI Masterclass Course](https://swiftuimasterclass.com) · 60% off
+### 💰 [Combine Swift • Complete Course](https://combineswift.com) · $40 off
 
 
 ## 🖥 Virtualization Software


### PR DESCRIPTION
I hope I don’t step on anyone’s toes with the typographic edits :) I think the emoji are much more obvious and easier to scan/compare when at the beginning of the lines, and taking the discount amount out of the links also helps with readability.